### PR TITLE
Use the last entry disk name instead of local

### DIFF
--- a/tests/Feature/Commands/RecordDiskMetricsCommandTest.php
+++ b/tests/Feature/Commands/RecordDiskMetricsCommandTest.php
@@ -24,7 +24,7 @@ class RecordDiskMetricsCommandTest extends TestCase
         $entry = DiskMonitorEntry::last();
         $this->assertEquals(0, $entry->file_count);
 
-        Storage::disk('local')->put('test.txt', 'text');
+        Storage::disk($entry->disk_name)->put('test.txt', 'text');
         $this->artisan(RecordDiskMetricsCommand::class)->assertExitCode(0);
         $entry = DiskMonitorEntry::last();
         $this->assertEquals(1, $entry->file_count);


### PR DESCRIPTION
If there will be more than 1 entry in the disk_names array in the config file. This test will run into an error.
The reason is that the last entry's disk name might not be 'local'.