### PR TITLE
Fixes invokable controller call

### DIFF
--- a/src/DiskMonitorServiceProvider.php
+++ b/src/DiskMonitorServiceProvider.php
@@ -5,7 +5,6 @@ namespace Spatie\DiskMonitor;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\ServiceProvider;
 use Spatie\DiskMonitor\Commands\RecordDiskMetricsCommand;
-use Spatie\DiskMonitor\Http\Controllers\DiskMetricsController;
 
 class DiskMonitorServiceProvider extends ServiceProvider
 {
@@ -62,7 +61,7 @@ class DiskMonitorServiceProvider extends ServiceProvider
     {
         Route::macro('diskMonitor', function (string $prefix) {
             Route::prefix($prefix)->group(function () {
-                Route::get('/', DiskMetricsController::class);
+                Route::get('/', '\Spatie\DiskMonitor\Http\Controllers\DiskMetricsController');
             });
         });
 

--- a/src/DiskMonitorServiceProvider.php
+++ b/src/DiskMonitorServiceProvider.php
@@ -61,7 +61,7 @@ class DiskMonitorServiceProvider extends ServiceProvider
     {
         Route::macro('diskMonitor', function (string $prefix) {
             Route::prefix($prefix)->group(function () {
-                Route::get('/', '\Spatie\DiskMonitor\Http\Controllers\DiskMetricsController');
+                Route::get('/', '\\' . DiskMetricsController::class);
             });
         });
 


### PR DESCRIPTION
It doesn't seem to work when installed in a fresh Laravel project. It always tries to find it in App\Http\Controllers namespace for some reason.